### PR TITLE
LLM Slash Command Separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,5 @@ Step 2: Run the migration script (HTML filename is currently hardcoded. Will con
 ```shell
 python3 migrations.py
 ```
+
+Note that you have to use the same embedding model for both the migration and the search queries.

--- a/README.md
+++ b/README.md
@@ -128,3 +128,15 @@ To run: `docker run --rm --pull always -p $(EXT_PORT):$(INT_PORT) surrealdb/surr
 I will be using `EXT_PORT=8011` and `INT_PORT=8011` for both the external and internal port, but you can change this to whatever you like.
 
 To run (hardcoded port): `docker run --rm --pull always -p 8011:8011 surrealdb/surrealdb:latest start --bind 0.0.0.0:8011 --user root --pass root`.
+
+### Migrations
+
+To migrate the Wiki data (for vector-based RAG search):
+
+Step 1: Export Wiki as an HTML file from OpenProject.
+
+Step 2: Run the migration script (HTML filename is currently hardcoded. Will convert to a CLI argument later).
+
+```shell
+python3 migrations.py
+```

--- a/app.py
+++ b/app.py
@@ -174,15 +174,15 @@ def slack_openproject():
     return jsonify({"response_type": "ephemeral", "text": f"Your task {task_title} was created on OpenProject: {project_title}"}), 200
 
 
-@app.route("/slack/llm", methods=["POST"])
-def slack_llm():
+@app.route("/slack/llm_create_task", methods=["POST"])
+def slack_llm_create_task():
     user_text = request.form.get("text", "")
     user_id = request.form.get("user_id", "")
     response_url = request.form.get("response_url", "")
 
     prompt = user_text if user_text else "Test prompt from Slack"
 
-    task = process_llm.delay(prompt, response_url)
+    task = process_llm.delay('llm_create_task', prompt, response_url)
     print('task', task)
 
     # 3) Return a quick 200 to Slack to avoid timeout
@@ -190,6 +190,25 @@ def slack_llm():
         "response_type": "ephemeral",
         "text": "Working on your request... I'll be back with an answer shortly."
     }), 200
+
+
+@app.route('/slack/llm_wiki', methods=['POST'])
+def slack_llm_wiki():
+    user_text = request.form.get("text", "")
+    user_id = request.form.get("user_id", "")
+    response_url = request.form.get("response_url", "")
+
+    prompt = user_text if user_text else "Test prompt from Slack"
+
+    task = process_llm.delay('llm_wiki', prompt, response_url)
+    print('task', task)
+
+    # 3) Return a quick 200 to Slack to avoid timeout
+    return jsonify({
+        "response_type": "ephemeral",
+        "text": "Working on your request... I'll be back with an answer shortly."
+    }), 200
+
 
 
 if __name__ == '__main__':

--- a/llm/rag/lib.py
+++ b/llm/rag/lib.py
@@ -56,10 +56,13 @@ DEFINE FIELD {self.table_name}.metadata TYPE object;           -- Extra metadata
         if use_remote:
             response = self.llm_client.embeddings.create(input=text, model="text-embedding-3-small")
             embedding = response.data[0].embedding
+            print("DATA TYPE OF EMBEDDING:", type(embedding))
             embedding_string = json.dumps(embedding)
         else:
             embedding = self.transformer.encode(text)
-            embedding_string = json.dumps(embedding.tolist())
+            e = embedding.tolist()
+            print("DATA TYPE OF EMBEDDING:", type(e))
+            embedding_string = json.dumps(e)
 
         v_q = f'''
         LET $query_vector = {embedding_string};

--- a/llm/rag/lib.py
+++ b/llm/rag/lib.py
@@ -56,12 +56,12 @@ DEFINE FIELD {self.table_name}.metadata TYPE object;           -- Extra metadata
         if use_remote:
             response = self.llm_client.embeddings.create(input=text, model="text-embedding-3-small")
             embedding = response.data[0].embedding
-            print("DATA TYPE OF EMBEDDING:", type(embedding))
+            print("DATA TYPE OF EMBEDDING:", type(embedding), type(embedding[0]), embedding[0])
             embedding_string = json.dumps(embedding)
         else:
             embedding = self.transformer.encode(text)
             e = embedding.tolist()
-            print("DATA TYPE OF EMBEDDING:", type(e))
+            print("DATA TYPE OF EMBEDDING:", type(e), type(e[0]), e[0])
             embedding_string = json.dumps(e)
 
         v_q = f'''

--- a/llm/rag/lib.py
+++ b/llm/rag/lib.py
@@ -57,11 +57,15 @@ DEFINE FIELD {self.table_name}.metadata TYPE object;           -- Extra metadata
             response = self.llm_client.embeddings.create(input=text, model="text-embedding-3-small")
             embedding = response.data[0].embedding
             print("DATA TYPE OF EMBEDDING:", type(embedding), type(embedding[0]), embedding[0])
+            # Remember that the issue is the dimensionality...
+            ## "The two vectors must be of the same dimension."
+            print("EMBEDDING DIMENSIONALITY:", len(embedding))
             embedding_string = json.dumps(embedding)
         else:
             embedding = self.transformer.encode(text)
             e = embedding.tolist()
             print("DATA TYPE OF EMBEDDING:", type(e), type(e[0]), e[0])
+            print("EMBEDDING DIMENSIONALITY:", len(e))
             embedding_string = json.dumps(e)
 
         v_q = f'''

--- a/llm/rag/lib.py
+++ b/llm/rag/lib.py
@@ -56,7 +56,6 @@ DEFINE FIELD {self.table_name}.metadata TYPE object;           -- Extra metadata
         if use_remote:
             response = self.llm_client.embeddings.create(input=text, model="text-embedding-3-small")
             embedding = response.data[0].embedding
-            print(f'Embedding response: {embedding}')
             embedding_string = json.dumps(embedding)
         else:
             embedding = self.transformer.encode(text)

--- a/llm/tools/op.py
+++ b/llm/tools/op.py
@@ -32,6 +32,8 @@ async def search_wiki(project_name: str, query: str, llm_client=None):
         for r in result:
             print(r)
         top_result = result[0].get('chunk_text', 'Something went wrong or maybe no results.')
+    except IndexError:
+        top_result = "No results found. Warning: Wiki may be empty (Hint: check SurrealDB)."
     except Exception as e:
         print("Something went wrong", results)
         print(f"Error: {e}")

--- a/llm/tools/op.py
+++ b/llm/tools/op.py
@@ -3,14 +3,14 @@ from settings import High, Normal
 
 """ WIKI SEARCH TOOL """
 
-async def search(rag, query: str):
+async def search(rag, query: str, use_remote: bool = False):
     await rag.connect()
 
-    results = await rag.search(query)
+    results = await rag.search(query, use_remote=use_remote)
 
     return results
 
-async def search_wiki(project_name: str, query: str):
+async def search_wiki(project_name: str, query: str, llm_client=None):
     # Placeholder implementation
     ###logger.debug(f"Searching {project_name} Wiki for {query}...")
     print((f"Searching {project_name} Wiki for {query}..."))
@@ -21,7 +21,10 @@ async def search_wiki(project_name: str, query: str):
 
     rag = RAG("wiki", DBConfig(SURREALDB_NS, SURREALDB_DB, SURREALDB_USER, SURREALDB_PASS, SURREALDB_HOST, SURREALDB_PORT))
 
-    results = await search(rag, query)
+    if llm_client:
+        rag.llm_client = llm_client
+
+    results = await search(rag, query, use_remote=True)
 
     try:
         result = results[1].get('result')

--- a/llm/tools/op.py
+++ b/llm/tools/op.py
@@ -29,8 +29,9 @@ async def search_wiki(project_name: str, query: str):
         for r in result:
             print(r)
         top_result = result[0].get('chunk_text', 'Something went wrong or maybe no results.')
-    except:
+    except Exception as e:
         print("Something went wrong", results)
+        print(f"Error: {e}")
         top_result = "Something went wrong."
 
     return top_result

--- a/tasks.py
+++ b/tasks.py
@@ -10,6 +10,10 @@ from llm.tools.op import provide_work_package_output_tool
 from llm.outputs.op import WorkPackageOutput
 from pydantic import ValidationError
 
+
+MAX_TOOL_CALLS = 5
+
+
 celery = Celery("app", broker="amqp://guest@localhost//")
 
 ENDPOINTS = dict(
@@ -63,6 +67,8 @@ def my_llm_call(endpoint: str, prompt: str):
     active_tool_calls = True
 
     while active_tool_calls:
+        if n > MAX_TOOL_CALLS:
+            return jsonify({"response_type": "ephemeral", "text": "Error calling LLM endpoint (too many iterations for some reason)."}), 500
         loop = asyncio.get_event_loop()
 
         for tool_call in tool_calls:

--- a/tasks.py
+++ b/tasks.py
@@ -71,8 +71,8 @@ def my_llm_call(endpoint: str, prompt: str):
             arguments = json.loads(tool_call.function.arguments)
 
             if function_name == 'search_wiki':
-                if loop.is_running(): tool_result = asyncio.ensure_future(search_wiki(**arguments))
-                else: tool_result = loop.run_until_complete(search_wiki(**arguments))
+                if loop.is_running(): tool_result = asyncio.ensure_future(search_wiki(**arguments, llm_client=client))
+                else: tool_result = loop.run_until_complete(search_wiki(**arguments, llm_client=client))
                 content = json.dumps(tool_result)
             elif function_name == 'create_work_package':
                 tool_result = create_work_package(**arguments)

--- a/tasks.py
+++ b/tasks.py
@@ -14,11 +14,11 @@ celery = Celery("app", broker="amqp://guest@localhost//")
 
 ENDPOINTS = dict(
     llm_create_task=dict(
-        prompt="",
+        prompt="You are a helpful expert project management assistant. Please create a new task in OpenProject. If the task is particularly unstructured, try to fill in the details as best as you can and use the 'Provide Work Package Output' tool to provide the structured data if necessary.",
         tools=[create_work_package_tool, provide_work_package_output_tool]
     ),
     llm_wiki=dict(
-        prompt="",
+        prompt="You are a helpful expert project management assistant. Please search the OpenProject wiki for information on the topic.",
         tools=[search_wiki_tool]
     )
 )

--- a/tasks.py
+++ b/tasks.py
@@ -28,7 +28,7 @@ ENDPOINTS = dict(
 )
 
 
-def my_llm_call(endpoint: str, prompt: str):
+def my_llm_call(endpoint: str, prompt: str) -> str:
     import openai
     import asyncio
 
@@ -52,7 +52,7 @@ def my_llm_call(endpoint: str, prompt: str):
     print('result:', result)
 
     if not result:
-        return jsonify({"response_type": "ephemeral", "text": "Error calling LLM endpoint"}), 500
+        return "Error calling LLM endpoint"
 
     n = 0
 
@@ -68,7 +68,7 @@ def my_llm_call(endpoint: str, prompt: str):
 
     while active_tool_calls:
         if n > MAX_TOOL_CALLS:
-            return jsonify({"response_type": "ephemeral", "text": "Error calling LLM endpoint (too many iterations for some reason)."}), 500
+            return "Error calling LLM endpoint (too many iterations for some reason)."
         loop = asyncio.get_event_loop()
 
         for tool_call in tool_calls:


### PR DESCRIPTION
In this PR, I separate the logic for each slash command use case rather than using a singular all purpose endpoint.

Before this separation, I was noticing a tendency for the LLM to sometimes use the wrong tool for the job.

I also added the option for using a remote OpenAI API call for embedding rather than the local embedding.

Finally, I added some more precise debug logging and exception handling, as well as a max tool call iteration mechanism.
