### PR TITLE
Repeated Slack Message Data

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,14 +39,15 @@ endpoint_case_switch = {
 }
 
 sendgrid_endpoint_case_switch = {
-    'dropped': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post(),
-    'bounce': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post(),
-    'click': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post(),
-    'open': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post(),
-    'deferred': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post(),
-    'delivered': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post(),
-    'spamreport': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post(),
-    'unsubscribed': lambda event: sendgridIssueWebhook(event_type=event['event'], email=event['email'], reason=event.get('reason', 'no reason')).post()
+    event_type: (lambda event, et=event_type: sendgridIssueWebhook(
+        event_type=et,
+        email=event['email'],
+        reason=event.get('reason', 'no reason')
+    ).post())
+    for event_type in [
+        'dropped', 'bounce', 'click', 'open', 'deferred',
+        'delivered', 'spamreport', 'unsubscribed'
+    ]
 }
 
 

--- a/app.py
+++ b/app.py
@@ -39,10 +39,10 @@ endpoint_case_switch = {
 }
 
 sendgrid_endpoint_case_switch = {
-    event_type: (lambda event, et=event_type: sendgridIssueWebhook(
-        event_type=et,
-        email=event['email'],
-        reason=event.get('reason', 'no reason')
+    event_type: (lambda event, et=event_type: create_sendgrid_issue_webhook(
+        et,
+        event['email'],
+        event.get('reason', 'no reason')
     ).post())
     for event_type in [
         'dropped', 'bounce', 'click', 'open', 'deferred',

--- a/app.py
+++ b/app.py
@@ -244,13 +244,16 @@ def slack_llm_wiki():
 def sendgrid_event_listener():
     events = request.get_json()
     for event in events:
-        event_string = event.get('event', '')
         print(f"Event: {event.get('event')} for {event.get('email')}")
-        if event.get('event') == 'dropped':
-            print(f"Reason: {event.get('reason')}")
-        if event_string:
-            status_code = sendgrid_endpoint_case_switch.get(event_string, lambda r: 400)(event)
-            print("SLACK SEND STATUS CODE:", status_code)
+        if event.get('event') == 'dropped': print(f"Reason: {event.get('reason')}")
+
+        handler = sendgrid_endpoint_case_switch.get(event_type)
+
+        if handler:
+            status_code = handler(event)
+            print(f"SLACK SEND STATUS CODE [{g.unique_event_id}]: {status_code}")
+        else:
+            print(f"No handler for event type: {event_type}")
     return jsonify({"status": "ok"}), 200
 
 

--- a/app.py
+++ b/app.py
@@ -38,12 +38,16 @@ endpoint_case_switch = {
     'reopen': lambda req: reopenIssueWebhook(issue=dict(issue=req.json['issue'])).post()
 }
 
-sendgrid_endpoint_case_switch = {
-    event_type: lambda event, et=event_type: create_sendgrid_issue_webhook(
-        et,
+def handle_sendgrid_event(event, event_type):
+    webhook = create_sendgrid_issue_webhook(
+        event_type,
         event['email'],
         event.get('reason', 'no reason')
-    ).post()
+    )
+    return webhook.post()
+
+sendgrid_endpoint_case_switch = {
+    event_type: lambda event, et=event_type: handle_sendgrid_event(event, et)
     for event_type in [
         'dropped', 'bounce', 'click', 'open', 'deferred',
         'delivered', 'spamreport', 'unsubscribed'

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ op = OpenProject(url=OPENPROJECT_URL, api_key=OPENPROJECT_API_KEY)
 
 import requests
 
-from flask import Flask, request, make_response, jsonify
+from flask import Flask, request, make_response, jsonify, g
 
 app = Flask(__name__)
 
@@ -41,10 +41,14 @@ endpoint_case_switch = {
 }
 
 def handle_sendgrid_event(event, event_type):
+    unique_id = str(uuid.uuid4())
+    g.unique_event_id = unique_id
+
     webhook = create_sendgrid_issue_webhook(
         event_type,
         event['email'],
-        event.get('reason', 'no reason')
+        event.get('reason', 'no reason'),
+        unique_id
     )
     status = webhook.post()
 

--- a/app.py
+++ b/app.py
@@ -244,6 +244,8 @@ def slack_llm_wiki():
 def sendgrid_event_listener():
     events = request.get_json()
     for event in events:
+        event_type = event.get('event')
+
         print(f"Event: {event.get('event')} for {event.get('email')}")
         if event.get('event') == 'dropped': print(f"Reason: {event.get('reason')}")
 

--- a/app.py
+++ b/app.py
@@ -10,6 +10,8 @@ import json
 
 import gc
 
+import uuid
+
 from pyopenproject.openproject import OpenProject
 from pyopenproject.model.project import Project
 from pyopenproject.model.work_package import WorkPackage

--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ from tasks import process_llm
 
 import json
 
+import gc
+
 from pyopenproject.openproject import OpenProject
 from pyopenproject.model.project import Project
 from pyopenproject.model.work_package import WorkPackage
@@ -44,7 +46,12 @@ def handle_sendgrid_event(event, event_type):
         event['email'],
         event.get('reason', 'no reason')
     )
-    return webhook.post()
+    status = webhook.post()
+
+    del webhook
+    gc.collect()
+
+    return status
 
 sendgrid_endpoint_case_switch = {
     event_type: lambda event, et=event_type: handle_sendgrid_event(event, et)

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from settings import MALFORMED_REQUEST, NO_SUCH_ENDPOINT, SUCCESS, SLACK_UNREACH
 from settings import GITHUB_REPO_OWNER, GITHUB_REPO_NAME, GITHUB_TOKEN
 from settings import OPENPROJECT_URL, OPENPROJECT_API_KEY
 from settings import LLM_API_KEY
-from webhooks.webhooks import openIssueWebhook, closeIssueWebhook, reopenIssueWebhook, sendgridIssueWebhook
+from webhooks.webhooks import openIssueWebhook, closeIssueWebhook, reopenIssueWebhook, create_sendgrid_issue_webhook
 
 from tasks import process_llm
 

--- a/app.py
+++ b/app.py
@@ -39,11 +39,11 @@ endpoint_case_switch = {
 }
 
 sendgrid_endpoint_case_switch = {
-    event_type: (lambda event, et=event_type: create_sendgrid_issue_webhook(
+    event_type: lambda event, et=event_type: create_sendgrid_issue_webhook(
         et,
         event['email'],
         event.get('reason', 'no reason')
-    ).post())
+    ).post()
     for event_type in [
         'dropped', 'bounce', 'click', 'open', 'deferred',
         'delivered', 'spamreport', 'unsubscribed'

--- a/webhooks/factories.py
+++ b/webhooks/factories.py
@@ -48,6 +48,7 @@ class SendGridWebhookFactory(WebhookFactory):
 
 class UniversalSGWebhookFactory(SendGridWebhookFactory):
     def createWebhook(self, name: str, **attributes) -> 'SGWebhook':
+        attributes['event_type'] = name
         return type(name+'SGWebhook', (SGWebhook,), attributes)
 
 sgWebhookFactory = UniversalSGWebhookFactory()

--- a/webhooks/interfaces.py
+++ b/webhooks/interfaces.py
@@ -49,24 +49,14 @@ class SGWebhook(Webhook):
         print(f"Posting to {self.slack_relay_endpoint} with the following data: Event type ({self.event_type}), Email ({self.email}), Reason ({self.reason})")
         unique_tag = uuid.uuid4()
         print(f"Posting with unique ID: {unique_tag}")
-        d = self.slack_comment_template.format(
+        formatted_blocks = self.slack_comment_template.format(
             event_type=self.event_type,
             email=self.email,
             reason=self.reason,
             unique_tag=unique_tag
         )
 
-        import copy
-
-        template_copy = copy.deepcopy(self.slack_comment_template)
-        template_copy[0]["text"]["text"] = template_copy[0]["text"]["text"].format(
-            event_type=self.event_type,
-            email=self.email,
-            reason=self.reason,
-            unique_tag=unique_tag
-        )
-
-        data = json.dumps({"blocks": template_copy})
+        data = json.dumps({"blocks": formatted_blocks})
 
         print("DEBUG LOG:", data)
 

--- a/webhooks/interfaces.py
+++ b/webhooks/interfaces.py
@@ -58,6 +58,10 @@ class SGWebhook(Webhook):
 
         self.slack_comment_template = None
 
-        req = requests.post(self.slack_relay_endpoint, headers={'Content-Type': 'application/json'}, data=json.dumps(dict(blocks=d)))
+        data = json.dumps(dict(blocks=d))
+
+        print("DEBUG LOG:", data)
+
+        req = requests.post(self.slack_relay_endpoint, headers={'Content-Type': 'application/json'}, data=data)
         return req.status_code
 

--- a/webhooks/interfaces.py
+++ b/webhooks/interfaces.py
@@ -56,9 +56,17 @@ class SGWebhook(Webhook):
             unique_tag=unique_tag
         )
 
-        self.slack_comment_template = None
+        import copy
 
-        data = json.dumps(dict(blocks=d))
+        template_copy = copy.deepcopy(self.slack_comment_template)
+        template_copy[0]["text"]["text"] = template_copy[0]["text"]["text"].format(
+            event_type=self.event_type,
+            email=self.email,
+            reason=self.reason,
+            unique_tag=unique_tag
+        )
+
+        data = json.dumps({"blocks": template_copy})
 
         print("DEBUG LOG:", data)
 

--- a/webhooks/interfaces.py
+++ b/webhooks/interfaces.py
@@ -12,6 +12,7 @@ class Webhook:
     issue: dict
 
     def __init__(self, **attributes):
+        print(f"Initializing Webhook with the following attributes: {attributes}")
         for key, val in attributes.items():
             setattr(self, key, val)
 
@@ -43,6 +44,7 @@ class SGWebhook(Webhook):
     # slack_relay_endpoint: str = '/sg'
 
     def post(self):
+        print(f"Posting to {self.slack_relay_endpoint} with the following data: Event type ({self.event_type}), Email ({self.email}), Reason ({self.reason})")
         d = self.slack_comment_template.format(
             event_type=self.event_type,
             email=self.email,

--- a/webhooks/interfaces.py
+++ b/webhooks/interfaces.py
@@ -1,4 +1,6 @@
 """"""
+import uuid
+
 import json
 
 import requests
@@ -45,10 +47,13 @@ class SGWebhook(Webhook):
 
     def post(self):
         print(f"Posting to {self.slack_relay_endpoint} with the following data: Event type ({self.event_type}), Email ({self.email}), Reason ({self.reason})")
+        unique_tag = uuid.uuid4()
+        print(f"Posting with unique ID: {unique_tag}")
         d = self.slack_comment_template.format(
             event_type=self.event_type,
             email=self.email,
-            reason=self.reason
+            reason=self.reason,
+            unique_tag=unique_tag
         )
         req = requests.post(self.slack_relay_endpoint, headers={'Content-Type': 'application/json'}, data=json.dumps(dict(blocks=d)))
         return req.status_code

--- a/webhooks/interfaces.py
+++ b/webhooks/interfaces.py
@@ -55,6 +55,9 @@ class SGWebhook(Webhook):
             reason=self.reason,
             unique_tag=unique_tag
         )
+
+        self.slack_comment_template = None
+
         req = requests.post(self.slack_relay_endpoint, headers={'Content-Type': 'application/json'}, data=json.dumps(dict(blocks=d)))
         return req.status_code
 

--- a/webhooks/interfaces.py
+++ b/webhooks/interfaces.py
@@ -56,6 +56,8 @@ class SGWebhook(Webhook):
             unique_tag=unique_tag
         )
 
+        print("Formatted blocks:", json.dumps(formatted_blocks, indent=2))
+
         data = json.dumps({"blocks": formatted_blocks})
 
         print("DEBUG LOG:", data)

--- a/webhooks/utils.py
+++ b/webhooks/utils.py
@@ -14,9 +14,10 @@ def format_block(block, **data):
 
 class SlackCommentTemplate:
     def __init__(self, *blocks: dict):
-        self.blocks = blocks
+        self.blocks = list(blocks)
 
     def format(self, **data):
-        return [format_block(block, **data) for block in self.blocks]
+        # Copy each block to prevent overwriting
+        return [format_block(block.copy(), **data) for block in self.blocks]
 
 

--- a/webhooks/utils.py
+++ b/webhooks/utils.py
@@ -3,12 +3,15 @@ from flask import render_template_string
 
 
 def format_block(block, **data):
-    if block['type'] == 'section':
-        block['text'] = format_block(block['text'], **data)
-        return block
-    elif block['type'] == 'mrkdwn':
-        block['text'] = render_template_string(block['text'], **data)
-        return block
+    # Avoid mutating the original block
+    new_block = block.copy()
+
+    if new_block['type'] == 'section':
+        new_block['text'] = format_block(new_block['text'], **data)
+        return new_block
+    elif new_block['type'] == 'mrkdwn':
+        new_block['text'] = render_template_string(new_block['text'], **data)
+        return new_block
 
 
 

--- a/webhooks/webhooks.py
+++ b/webhooks/webhooks.py
@@ -70,11 +70,12 @@ universal_sg_slack_template = SlackCommentTemplate(*[
     }
 ])
 
-def create_sendgrid_issue_webhook(event_type, email, reason):
+def create_sendgrid_issue_webhook(event_type, email, reason, unique_id):
     webhook_cls = sgWebhookFactory.createWebhook(
         event_type,
         slack_comment_template=universal_sg_slack_template,
         email=email,
-        reason=reason
+        reason=reason,
+        unique_tag=unique_id
     )
     return webhook_cls()

--- a/webhooks/webhooks.py
+++ b/webhooks/webhooks.py
@@ -65,7 +65,7 @@ universal_sg_slack_template = SlackCommentTemplate(*[
         "type": "section",
         "text": {
             "type": "mrkdwn",
-            "text": "[{{ event_type }}]({{ email }}) has occured with reason: {{ reason }}."
+            "text": "[{{ event_type }}: {{unique_tag}}]({{ email }}) has occured with reason: {{ reason }}."
         }
     }
 ])

--- a/webhooks/webhooks.py
+++ b/webhooks/webhooks.py
@@ -71,9 +71,10 @@ universal_sg_slack_template = SlackCommentTemplate(*[
 ])
 
 def create_sendgrid_issue_webhook(event_type, email, reason):
-    return sgWebhookFactory.createWebhook(
+    webhook_cls = sgWebhookFactory.createWebhook(
         event_type,
         slack_comment_template=universal_sg_slack_template,
         email=email,
         reason=reason
     )
+    return webhook_cls()

--- a/webhooks/webhooks.py
+++ b/webhooks/webhooks.py
@@ -70,6 +70,10 @@ universal_sg_slack_template = SlackCommentTemplate(*[
     }
 ])
 
-sendgridIssueWebhook = sgWebhookFactory.createWebhook('open',
-    slack_comment_template=universal_sg_slack_template
-)
+def create_sendgrid_issue_webhook(event_type, email, reason):
+    return sgWebhookFactory.createWebhook(
+        event_type,
+        slack_comment_template=universal_sg_slack_template,
+        email=email,
+        reason=reason
+    )


### PR DESCRIPTION
This PR fixes the bug where data being sent to Slack (care of a SendGrid webhook endpoint) was repeating when new requests came through.